### PR TITLE
feat: add Starter-accessible live market-data endpoints (0.2.3-beta.0)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "fmp-docs": "0.0.0",
+    "fmp-ai-tools-openai-example": "0.1.0",
+    "fmp-ai-tools-vercel-ai-example": "0.1.0",
+    "fmp-node-api": "0.2.1",
+    "fmp-ai-tools": "0.2.1",
+    "fmp-node-types": "0.2.0"
+  },
+  "changesets": []
+}

--- a/.changeset/starter-live-market-data.md
+++ b/.changeset/starter-live-market-data.md
@@ -1,0 +1,21 @@
+---
+'fmp-node-types': patch
+'fmp-node-api': patch
+'fmp-ai-tools': patch
+---
+
+Add Starter-accessible live market-data endpoints and migrate two market methods to the `stable` surface.
+
+New endpoints (and matching AI tools for both the Vercel AI SDK and OpenAI Agents):
+
+- `fmp.quote.getQuoteShort(symbol)` — lean price/change/volume quote (`getStockQuoteShort` tool)
+- `fmp.aftermarket.getTrade(symbol)` / `fmp.aftermarket.getQuote(symbol)` — new `aftermarket` endpoint class for extended-hours trade and bid/ask (`getAftermarketTrade` / `getAftermarketQuote` tools)
+- `fmp.stock.getPriceChange(symbol)` — price change across 1D…10Y/max horizons (`getStockPriceChange` tool)
+- `fmp.market.getIndustryPESnapshot({ date })` — per-industry P/E snapshot (`getIndustryPESnapshot` tool)
+
+**Breaking changes** (two methods migrated from `v3` to `stable`):
+
+- `fmp.market.getMarketHours()` now returns an **array** of per-exchange market hours (`ExchangeMarketHours[]`, with `isMarketOpen`) instead of a single `MarketHours` object. The `MarketHours` and `MarketHoliday` types are removed.
+- `fmp.market.getSectorPerformance(params)` now **requires** `{ date }` (YYYY-MM-DD, plus optional `exchange`/`sector`) and returns `MarketSectorPerformance[]` with `{ date, sector, exchange, averageChange: number }` instead of `{ sector, changesPercentage: string }`. The `getSectorPerformance` AI tool now takes a `date` input.
+
+Note: on the FMP Starter plan the sector/industry snapshot endpoints are available for recent dates only; older `date` values require a higher tier.

--- a/apps/docs/src/app/docs/api/aftermarket/page.mdx
+++ b/apps/docs/src/app/docs/api/aftermarket/page.mdx
@@ -1,0 +1,122 @@
+# Aftermarket Endpoints
+
+The Aftermarket Endpoints provide extended-hours (pre/post-market) trade and quote data for a symbol — the latest aftermarket trade and the latest aftermarket bid/ask.
+
+All endpoints return responses with a consistent structure: `{ success: boolean, data: T | null, error: string | null, status: number }`.
+
+## Available Methods
+
+<ApiTable
+  endpoints={[
+    {
+      method: 'GET',
+      path: '/stable/aftermarket-trade',
+      description: 'Get the latest extended-hours trade for a symbol',
+    },
+    {
+      method: 'GET',
+      path: '/stable/aftermarket-quote',
+      description: 'Get the latest extended-hours bid/ask quote for a symbol',
+    },
+  ]}
+/>
+
+## Get Aftermarket Trade
+
+Retrieve the most recent extended-hours trade, including price, trade size, and timestamp.
+
+<CodeBlock language="typescript">{`const trade = await fmp.aftermarket.getTrade('AAPL');`}</CodeBlock>
+
+<ParameterTable
+  parameters={[
+    {
+      name: 'symbol',
+      type: 'string',
+      required: true,
+      description: 'Stock symbol (e.g., "AAPL")',
+    },
+  ]}
+/>
+
+### Example Response
+
+<CodeBlock language="typescript">
+  {`{
+    success: true,
+    data: {
+      symbol: 'AAPL',
+      price: 296.28,
+      tradeSize: 1,
+      timestamp: 1781268145000
+    },
+    error: null,
+    status: 200
+}`}
+</CodeBlock>
+
+## Get Aftermarket Quote
+
+Retrieve the most recent extended-hours bid/ask quote, including bid/ask prices and sizes, volume, and timestamp.
+
+<CodeBlock language="typescript">{`const quote = await fmp.aftermarket.getQuote('AAPL');`}</CodeBlock>
+
+<ParameterTable
+  parameters={[
+    {
+      name: 'symbol',
+      type: 'string',
+      required: true,
+      description: 'Stock symbol (e.g., "AAPL")',
+    },
+  ]}
+/>
+
+### Example Response
+
+<CodeBlock language="typescript">
+  {`{
+    success: true,
+    data: {
+      symbol: 'AAPL',
+      bidSize: 9,
+      bidPrice: 296.24,
+      askSize: 202,
+      askPrice: 296.29,
+      volume: 220963.66824,
+      timestamp: 1781268138000
+    },
+    error: null,
+    status: 200
+}`}
+</CodeBlock>
+
+## Response Types
+
+### AftermarketTrade
+
+<CodeBlock language="typescript">
+  {`interface AftermarketTrade {
+  symbol: string;
+  price: number;
+  tradeSize: number;
+  timestamp: number;
+}`}
+</CodeBlock>
+
+### AftermarketQuote
+
+<CodeBlock language="typescript">
+  {`interface AftermarketQuote {
+  symbol: string;
+  bidSize: number;
+  bidPrice: number;
+  askSize: number;
+  askPrice: number;
+  volume: number;
+  timestamp: number;
+}`}
+</CodeBlock>
+
+---
+
+**Looking for regular-session data?** See the [Quote Endpoints](/docs/api/quote) and [Stock Endpoints](/docs/api/stock).

--- a/apps/docs/src/app/docs/api/layout.tsx
+++ b/apps/docs/src/app/docs/api/layout.tsx
@@ -31,6 +31,7 @@ const apiNavigationGroups = [
     title: 'Market Data',
     items: [
       { name: 'Market Endpoints', href: '/docs/api/market' },
+      { name: 'Aftermarket Endpoints', href: '/docs/api/aftermarket' },
       { name: 'Economic Endpoints', href: '/docs/api/economic' },
       { name: 'News Endpoints', href: '/docs/api/news' },
     ],

--- a/apps/docs/src/app/docs/api/market/page.mdx
+++ b/apps/docs/src/app/docs/api/market/page.mdx
@@ -13,8 +13,8 @@ Access market-wide data including performance metrics, trading hours, sector inf
     },
     {
       method: 'GET',
-      path: '/market-hours',
-      description: 'Get market hours and status',
+      path: '/stable/all-exchange-market-hours',
+      description: 'Get trading hours and open/closed status for all exchanges',
     },
     {
       method: 'GET',
@@ -33,8 +33,13 @@ Access market-wide data including performance metrics, trading hours, sector inf
     },
     {
       method: 'GET',
-      path: '/sector-performance',
-      description: 'Get sector performance data',
+      path: '/stable/sector-performance-snapshot',
+      description: 'Get sector performance snapshot for a date',
+    },
+    {
+      method: 'GET',
+      path: '/stable/industry-pe-snapshot',
+      description: 'Get industry P/E snapshot for a date',
     },
     {
       method: 'GET',
@@ -89,40 +94,37 @@ Retrieve overall market performance data including major indices.
 
 ## Get Market Hours
 
-Retrieve current market trading hours and status information.
+Retrieve trading hours and the current open/closed status for every supported exchange. Returns one record per exchange.
 
-<CodeBlock language="typescript">{`const hours = await fmp.market.getMarketHours();`}</CodeBlock>
+<CodeBlock language="typescript">{`const hours = await fmp.market.getMarketHours();
+
+// Check whether the NASDAQ is currently open
+const nasdaq = hours.data.find(e => e.exchange === 'NASDAQ');
+console.log(nasdaq?.isMarketOpen);`}</CodeBlock>
 
 ### Example Response
 
 <CodeBlock language="typescript">
   {`{
   success: true,
-  data: {
-    stockExchangeName: 'NASDAQ',
-    stockMarketHours: {
-      openingHour: '09:30',
-      closingHour: '16:00'
+  data: [
+    {
+      exchange: 'NASDAQ',
+      name: 'NASDAQ Global Market',
+      openingHour: '09:30 AM -04:00',
+      closingHour: '04:00 PM -04:00',
+      timezone: 'America/New_York',
+      isMarketOpen: true
     },
-    stockMarketHolidays: [
-      {
-        year: 2024,
-        'Martin Luther King, Jr. Day': '2024-01-15',
-        "Presidents' Day": '2024-02-19',
-        'Good Friday': '2024-03-29',
-        'Memorial Day': '2024-05-27',
-        Juneteenth: '2024-06-19',
-        'Independence Day': '2024-07-04',
-        'Labor Day': '2024-09-02',
-        'Thanksgiving Day': '2024-11-28',
-        Christmas: '2024-12-25'
-      }
-    ],
-    isTheStockMarketOpen: true,
-    isTheEuronextMarketOpen: false,
-    isTheForexMarketOpen: true,
-    isTheCryptoMarketOpen: true
-  }
+    {
+      exchange: 'LSE',
+      name: 'London Stock Exchange',
+      openingHour: '08:00 AM +01:00',
+      closingHour: '04:30 PM +01:00',
+      timezone: 'Europe/London',
+      isMarketOpen: false
+    }
+  ]
 }`}
 </CodeBlock>
 
@@ -200,11 +202,38 @@ Retrieve the most actively traded stocks by volume.
 
 ## Get Sector Performance
 
-Retrieve performance data organized by market sectors.
+Retrieve a sector-performance snapshot for a given date, showing the average change per sector broken out by exchange. A `date` (YYYY-MM-DD) is required; `exchange` and `sector` are optional filters.
 
 <CodeBlock language="typescript">
-  {`const sectors = await fmp.market.getSectorPerformance();`}
+  {`const sectors = await fmp.market.getSectorPerformance({ date: '2024-06-10' });
+
+// Optionally filter to a single exchange
+const nyse = await fmp.market.getSectorPerformance({ date: '2024-06-10', exchange: 'NYSE' });`}
+
 </CodeBlock>
+
+<ParameterTable
+  parameters={[
+    {
+      name: 'date',
+      type: 'string',
+      required: true,
+      description: 'Snapshot date in YYYY-MM-DD format',
+    },
+    {
+      name: 'exchange',
+      type: 'string',
+      required: false,
+      description: 'Optional exchange filter (e.g., NASDAQ, NYSE)',
+    },
+    {
+      name: 'sector',
+      type: 'string',
+      required: false,
+      description: 'Optional sector filter (e.g., Technology)',
+    },
+  ]}
+/>
 
 ### Example Response
 
@@ -213,28 +242,75 @@ Retrieve performance data organized by market sectors.
   success: true,
   data: [
     {
+      date: '2024-06-10',
       sector: 'Technology',
-      changesPercentage: '1.25%'
+      exchange: 'NASDAQ',
+      averageChange: 1.2503
     },
     {
+      date: '2024-06-10',
       sector: 'Healthcare',
-      changesPercentage: '0.87%'
-    },
-    {
-      sector: 'Financial Services',
-      changesPercentage: '0.45%'
-    },
-    {
-      sector: 'Consumer Cyclical',
-      changesPercentage: '0.32%'
-    },
-    {
-      sector: 'Communication Services',
-      changesPercentage: '0.18%'
+      exchange: 'NASDAQ',
+      averageChange: -0.4417
     }
   ]
 }`}
 </CodeBlock>
+
+## Get Industry P/E Snapshot
+
+Retrieve an industry P/E snapshot for a given date, showing the average price-to-earnings ratio per industry broken out by exchange. A `date` (YYYY-MM-DD) is required; `exchange` and `industry` are optional filters.
+
+<CodeBlock language="typescript">
+  {`const pe = await fmp.market.getIndustryPESnapshot({ date: '2024-06-10' });`}
+</CodeBlock>
+
+<ParameterTable
+  parameters={[
+    {
+      name: 'date',
+      type: 'string',
+      required: true,
+      description: 'Snapshot date in YYYY-MM-DD format',
+    },
+    {
+      name: 'exchange',
+      type: 'string',
+      required: false,
+      description: 'Optional exchange filter (e.g., NASDAQ, NYSE)',
+    },
+    {
+      name: 'industry',
+      type: 'string',
+      required: false,
+      description: 'Optional industry filter (e.g., Software)',
+    },
+  ]}
+/>
+
+### Example Response
+
+<CodeBlock language="typescript">
+  {`{
+  success: true,
+  data: [
+    {
+      date: '2024-06-10',
+      industry: 'Software - Application',
+      exchange: 'NASDAQ',
+      pe: 31.0862
+    },
+    {
+      date: '2024-06-10',
+      industry: 'Aerospace & Defense',
+      exchange: 'NASDAQ',
+      pe: 70.9790
+    }
+  ]
+}`}
+</CodeBlock>
+
+> **Note:** On the FMP Starter plan, the snapshot endpoints are available for recent dates only; older `date` values require a higher tier.
 
 ## Get Market Index
 
@@ -292,33 +368,16 @@ Retrieve detailed market index data.
 }`}
 </CodeBlock>
 
-### MarketHours
+### ExchangeMarketHours
 
 <CodeBlock language="typescript">
-{`interface MarketHours {
-  stockExchangeName: string;
-  stockMarketHours: {
-    openingHour: string;
-    closingHour: string;
-  };
-  stockMarketHolidays: MarketHoliday[];
-  isTheStockMarketOpen: boolean;
-  isTheEuronextMarketOpen: boolean;
-  isTheForexMarketOpen: boolean;
-  isTheCryptoMarketOpen: boolean;
-}
-
-interface MarketHoliday {
-year: number;
-'Martin Luther King, Jr. Day'?: string;
-"Presidents' Day"?: string;
-'Good Friday'?: string;
-'Memorial Day'?: string;
-Juneteenth?: string;
-'Independence Day'?: string;
-'Labor Day'?: string;
-'Thanksgiving Day'?: string;
-Christmas?: string;
+{`interface ExchangeMarketHours {
+  exchange: string;
+  name: string;
+  openingHour: string;
+  closingHour: string;
+  timezone: string;
+  isMarketOpen: boolean;
 }`}
 
 </CodeBlock>
@@ -327,8 +386,21 @@ Christmas?: string;
 
 <CodeBlock language="typescript">
   {`interface MarketSectorPerformance {
+  date: string;
   sector: string;
-  changesPercentage: string; // Formatted string, e.g. "1.23%"
+  exchange: string;
+  averageChange: number;
+}`}
+</CodeBlock>
+
+### IndustryPESnapshot
+
+<CodeBlock language="typescript">
+  {`interface IndustryPESnapshot {
+  date: string;
+  industry: string;
+  exchange: string;
+  pe: number;
 }`}
 </CodeBlock>
 

--- a/apps/docs/src/app/docs/api/quote/page.mdx
+++ b/apps/docs/src/app/docs/api/quote/page.mdx
@@ -18,6 +18,11 @@ The Quote Endpoints provide unified access to real-time quotes, historical data,
     },
     {
       method: 'GET',
+      path: '/stable/quote-short',
+      description: 'Get a short quote (price, change, volume) for any asset type',
+    },
+    {
+      method: 'GET',
       path: '/historical-price-full/{symbol}',
       description: 'Get historical price data for any asset type',
     },
@@ -103,6 +108,37 @@ const forexQuote = await fmp.quote.getQuote('EURUSD');
 // ETF quote
 const etfQuote = await fmp.quote.getQuote('SPY');`}
 
+</CodeBlock>
+
+## Get Short Quote
+
+Retrieve a lean quote with just price, change, and volume. Lighter on bandwidth than the full quote — useful for frequent polling.
+
+<CodeBlock language="typescript">{`const short = await fmp.quote.getQuoteShort('AAPL');`}</CodeBlock>
+
+<ParameterTable
+  parameters={[
+    {
+      name: 'symbol',
+      type: 'string',
+      required: true,
+      description: 'Asset symbol (e.g., "AAPL", "BTCUSD", "EURUSD")',
+    },
+  ]}
+/>
+
+### Example Response
+
+<CodeBlock language="typescript">
+  {`{
+    success: true,
+    data: {
+      symbol: 'AAPL',
+      price: 150.25,
+      change: 3.15,
+      volume: 45678900
+    }
+}`}
 </CodeBlock>
 
 ## Get Multiple Quotes

--- a/apps/docs/src/app/docs/api/stock/page.mdx
+++ b/apps/docs/src/app/docs/api/stock/page.mdx
@@ -33,6 +33,11 @@ All endpoints return responses with a consistent structure: `{ success: boolean,
       path: '/stock/full/real-time-price/{symbols}',
       description: 'Get full real-time price data for multiple stocks',
     },
+    {
+      method: 'GET',
+      path: '/stable/stock-price-change',
+      description: 'Get price change percentages across standard horizons',
+    },
   ]}
 />
 
@@ -64,6 +69,50 @@ Retrieve market capitalization data for a specific stock.
       symbol: 'AAPL',
       date: '2023-12-29',
       marketCap: 2375000000000
+    },
+    error: null,
+    status: 200
+}`}
+</CodeBlock>
+
+## Get Price Change
+
+Retrieve the percentage price change for a stock across standard horizons (1D, 5D, 1M, 3M, 6M, YTD, 1Y, 3Y, 5Y, 10Y, and max) in a single call.
+
+<CodeBlock language="typescript">
+  {`const change = await fmp.stock.getPriceChange('AAPL');
+console.log(change.data.ytd, change.data['1Y']);`}
+</CodeBlock>
+
+<ParameterTable
+  parameters={[
+    {
+      name: 'symbol',
+      type: 'string',
+      required: true,
+      description: 'Stock symbol',
+    },
+  ]}
+/>
+
+### Example Response
+
+<CodeBlock language="typescript">
+  {`{
+    success: true,
+    data: {
+      symbol: 'AAPL',
+      '1D': 1.38898,
+      '5D': -5.50726,
+      '1M': 0.28154,
+      '3M': 15.58883,
+      '6M': 6.23473,
+      ytd: 8.74347,
+      '1Y': 48.40863,
+      '3Y': 60.85206,
+      '5Y': 126.57112,
+      '10Y': 1114.58505,
+      max: 230231.12583
     },
     error: null,
     status: 200

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -142,6 +142,7 @@ const fmp = new FMP({
 - **`fmp.mutualFund`** - Mutual fund data
 - **`fmp.economic`** - Economic indicators
 - **`fmp.market`** - Market-wide data and performance
+- **`fmp.aftermarket`** - Extended-hours (pre/post-market) trade and quote data
 - **`fmp.list`** - Stock lists and indices
 - **`fmp.screener`** - Stock screener with filters and available exchanges/sectors/industries/countries
 - **`fmp.calendar`** - Earnings and economic calendar
@@ -161,6 +162,9 @@ const quote = await fmp.quote.getQuote('AAPL');
 
 // Get multiple quotes
 const quotes = await fmp.quote.getQuotes(['AAPL', 'MSFT', 'GOOGL']);
+
+// Get a short quote (price, change, volume only)
+const shortQuote = await fmp.quote.getQuoteShort('AAPL');
 
 // Get historical prices
 const historical = await fmp.quote.getHistoricalPrice({
@@ -199,6 +203,9 @@ const fullRealTimeData = await fmp.stock.getRealTimePriceForMultipleStocks([
   'MSFT',
   'GOOGL',
 ]);
+
+// Get price change across horizons (1D, 5D, 1M ... 10Y, max)
+const priceChange = await fmp.stock.getPriceChange('AAPL');
 ```
 
 ### Financial Statements
@@ -233,7 +240,7 @@ const ratios = await fmp.financial.getFinancialRatios({ symbol: 'AAPL' });
 ### Market Data
 
 ```typescript
-// Get market hours
+// Get market hours + open/closed status for all exchanges
 const hours = await fmp.market.getMarketHours();
 
 // Get market performance
@@ -246,8 +253,21 @@ const losers = await fmp.market.getLosers();
 // Get most active stocks
 const mostActive = await fmp.market.getMostActive();
 
-// Get sector performance
-const sectors = await fmp.market.getSectorPerformance();
+// Get a sector-performance snapshot for a date
+const sectors = await fmp.market.getSectorPerformance({ date: '2024-06-10' });
+
+// Get an industry P/E snapshot for a date
+const industryPE = await fmp.market.getIndustryPESnapshot({ date: '2024-06-10' });
+```
+
+### Aftermarket Data
+
+```typescript
+// Get the latest extended-hours trade
+const trade = await fmp.aftermarket.getTrade('AAPL');
+
+// Get the latest extended-hours bid/ask quote
+const aftermarketQuote = await fmp.aftermarket.getQuote('AAPL');
 ```
 
 ### Economic Indicators

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmp-node-api",
-  "version": "0.2.1",
+  "version": "0.2.3-beta.0",
   "description": "A comprehensive Node.js wrapper for Financial Modeling Prep API",
   "disclaimer": "This package is not affiliated with, endorsed by, or sponsored by Financial Modeling Prep (FMP). This is an independent, community-developed wrapper.",
   "main": "./dist/index.js",

--- a/packages/api/scripts/live/manifest.ts
+++ b/packages/api/scripts/live/manifest.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import {
   // quote
   QuoteSchema,
+  QuoteShortSchema,
   HistoricalPriceResponseSchema,
   IntradayPriceSchema,
   // stock
@@ -17,10 +18,15 @@ import {
   StockDividendResponseSchema,
   StockRealTimePriceSchema,
   StockRealTimePriceFullSchema,
+  StockPriceChangeSchema,
+  // aftermarket
+  AftermarketTradeSchema,
+  AftermarketQuoteSchema,
   // market
-  MarketHoursSchema,
+  ExchangeMarketHoursSchema,
   MarketPerformanceSchema,
   MarketSectorPerformanceSchema,
+  IndustryPESnapshotSchema,
   MarketIndexSchema,
   // financial
   IncomeStatementSchema,
@@ -129,6 +135,7 @@ import type { FMP } from '../../src/fmp';
 export type Category =
   | 'quote'
   | 'stock'
+  | 'aftermarket'
   | 'financial'
   | 'market'
   | 'calendar'
@@ -163,10 +170,13 @@ export interface LiveCase {
 }
 
 const RANGE = { from: '2024-01-01', to: '2024-01-31' };
+// A past trading day with snapshot data available (sector/industry snapshots).
+const SNAPSHOT_DATE = '2024-06-10';
 
 export const manifest: LiveCase[] = [
   // ---- quote ----
   { category: 'quote', name: 'getQuote(AAPL)', schema: QuoteSchema, kind: 'object', call: (fmp) => fmp.quote.getQuote('AAPL') },
+  { category: 'quote', name: 'getQuoteShort(AAPL)', schema: QuoteShortSchema, kind: 'object', call: (fmp) => fmp.quote.getQuoteShort('AAPL') },
   { category: 'quote', name: 'getQuotes([AAPL,GOOGL])', schema: QuoteSchema, kind: 'array', call: (fmp) => fmp.quote.getQuotes(['AAPL', 'GOOGL']) },
   { category: 'quote', name: 'getHistoricalPrice(AAPL)', schema: HistoricalPriceResponseSchema, kind: 'object', call: (fmp) => fmp.quote.getHistoricalPrice({ symbol: 'AAPL', ...RANGE }) },
   { category: 'quote', name: 'getIntraday(AAPL,5min)', schema: IntradayPriceSchema, kind: 'array', call: (fmp) => fmp.quote.getIntraday({ symbol: 'AAPL', interval: '5min', from: '2024-01-02', to: '2024-01-03' }) },
@@ -177,14 +187,23 @@ export const manifest: LiveCase[] = [
   { category: 'stock', name: 'getDividendHistory(AAPL)', schema: StockDividendResponseSchema, kind: 'object', call: (fmp) => fmp.stock.getDividendHistory('AAPL') },
   { category: 'stock', name: 'getRealTimePrice([AAPL,MSFT])', schema: StockRealTimePriceSchema, kind: 'array', call: (fmp) => fmp.stock.getRealTimePrice(['AAPL', 'MSFT']) },
   { category: 'stock', name: 'getRealTimePriceForMultipleStocks([AAPL,MSFT])', schema: StockRealTimePriceFullSchema, kind: 'array', call: (fmp) => fmp.stock.getRealTimePriceForMultipleStocks(['AAPL', 'MSFT']) },
+  { category: 'stock', name: 'getPriceChange(AAPL)', schema: StockPriceChangeSchema, kind: 'object', call: (fmp) => fmp.stock.getPriceChange('AAPL') },
+
+  // ---- aftermarket ----
+  { category: 'aftermarket', name: 'getTrade(AAPL)', schema: AftermarketTradeSchema, kind: 'object', call: (fmp) => fmp.aftermarket.getTrade('AAPL') },
+  { category: 'aftermarket', name: 'getQuote(AAPL)', schema: AftermarketQuoteSchema, kind: 'object', call: (fmp) => fmp.aftermarket.getQuote('AAPL') },
 
   // ---- market ----
-  { category: 'market', name: 'getMarketHours()', schema: MarketHoursSchema, kind: 'object', call: (fmp) => fmp.market.getMarketHours() },
+  { category: 'market', name: 'getMarketHours()', schema: ExchangeMarketHoursSchema, kind: 'array', call: (fmp) => fmp.market.getMarketHours() },
   { category: 'market', name: 'getMarketPerformance()', schema: MarketIndexSchema, kind: 'array', call: (fmp) => fmp.market.getMarketPerformance() },
   { category: 'market', name: 'getGainers()', schema: MarketPerformanceSchema, kind: 'array', call: (fmp) => fmp.market.getGainers() },
   { category: 'market', name: 'getLosers()', schema: MarketPerformanceSchema, kind: 'array', call: (fmp) => fmp.market.getLosers() },
   { category: 'market', name: 'getMostActive()', schema: MarketPerformanceSchema, kind: 'array', call: (fmp) => fmp.market.getMostActive() },
-  { category: 'market', name: 'getSectorPerformance()', schema: MarketSectorPerformanceSchema, kind: 'array', call: (fmp) => fmp.market.getSectorPerformance() },
+  // The snapshot endpoints are accessible on Starter for RECENT dates only;
+  // a historical `date` value is a premium parameter (402), so these are
+  // plan-locked by default. Schemas were confirmed live against a recent date.
+  { category: 'market', name: 'getSectorPerformance(snapshot)', schema: MarketSectorPerformanceSchema, kind: 'array', planLocked: true, call: (fmp) => fmp.market.getSectorPerformance({ date: SNAPSHOT_DATE }) },
+  { category: 'market', name: 'getIndustryPESnapshot(snapshot)', schema: IndustryPESnapshotSchema, kind: 'array', planLocked: true, call: (fmp) => fmp.market.getIndustryPESnapshot({ date: SNAPSHOT_DATE }) },
   { category: 'market', name: 'getMarketIndex()', schema: MarketIndexSchema, kind: 'array', call: (fmp) => fmp.market.getMarketIndex() },
 
   // ---- financial ----

--- a/packages/api/scripts/test-endpoint.ts
+++ b/packages/api/scripts/test-endpoint.ts
@@ -386,7 +386,10 @@ async function testEndpoint() {
         result = await fmp.market.getMostActive();
         break;
       case 'sector-performance':
-        result = await fmp.market.getSectorPerformance();
+        result = await fmp.market.getSectorPerformance({ date: '2024-06-10' });
+        break;
+      case 'industry-pe':
+        result = await fmp.market.getIndustryPESnapshot({ date: '2024-06-10' });
         break;
       case 'market-index':
         result = await fmp.market.getMarketIndex();

--- a/packages/api/src/__tests__/endpoints/aftermarket.test.ts
+++ b/packages/api/src/__tests__/endpoints/aftermarket.test.ts
@@ -1,0 +1,61 @@
+import { AftermarketEndpoints } from '../../endpoints/aftermarket';
+import { FMPClient } from '../../client';
+
+// Mock the FMPClient
+jest.mock('../../client');
+
+describe('AftermarketEndpoints', () => {
+  let aftermarketEndpoints: AftermarketEndpoints;
+  let mockClient: jest.Mocked<FMPClient>;
+
+  beforeEach(() => {
+    mockClient = new FMPClient({ apiKey: 'test-key' }) as jest.Mocked<FMPClient>;
+    aftermarketEndpoints = new AftermarketEndpoints(mockClient);
+  });
+
+  describe('getTrade', () => {
+    it('should get aftermarket trade using /aftermarket-trade stable endpoint', async () => {
+      const mockResponse = {
+        success: true,
+        data: { symbol: 'AAPL', price: 296.28, tradeSize: 1, timestamp: 1781268145000 },
+        error: null,
+        status: 200,
+      };
+      mockClient.getSingle.mockResolvedValue(mockResponse);
+
+      const result = await aftermarketEndpoints.getTrade('AAPL');
+
+      expect(mockClient.getSingle).toHaveBeenCalledWith('/aftermarket-trade', 'stable', {
+        symbol: 'AAPL',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getQuote', () => {
+    it('should get aftermarket quote using /aftermarket-quote stable endpoint', async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          symbol: 'AAPL',
+          bidSize: 9,
+          bidPrice: 296.24,
+          askSize: 202,
+          askPrice: 296.29,
+          volume: 220963.66,
+          timestamp: 1781268138000,
+        },
+        error: null,
+        status: 200,
+      };
+      mockClient.getSingle.mockResolvedValue(mockResponse);
+
+      const result = await aftermarketEndpoints.getQuote('AAPL');
+
+      expect(mockClient.getSingle).toHaveBeenCalledWith('/aftermarket-quote', 'stable', {
+        symbol: 'AAPL',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/packages/api/src/__tests__/endpoints/market.test.ts
+++ b/packages/api/src/__tests__/endpoints/market.test.ts
@@ -14,10 +14,10 @@ describe('MarketEndpoints', () => {
   });
 
   describe('getMarketHours', () => {
-    it('should get market hours using /market-hours endpoint', async () => {
+    it('should get market hours using /all-exchange-market-hours stable endpoint', async () => {
       const mockResponse = {
         success: true,
-        data: [{ isTheStockMarketOpen: true }],
+        data: [{ exchange: 'NASDAQ', isMarketOpen: true }],
         error: null,
         status: 200,
       };
@@ -25,7 +25,7 @@ describe('MarketEndpoints', () => {
 
       const result = await marketEndpoints.getMarketHours();
 
-      expect(mockClient.get).toHaveBeenCalledWith('/market-hours', 'v3');
+      expect(mockClient.get).toHaveBeenCalledWith('/all-exchange-market-hours', 'stable');
       expect(result).toEqual(mockResponse);
     });
   });
@@ -99,18 +99,45 @@ describe('MarketEndpoints', () => {
   });
 
   describe('getSectorPerformance', () => {
-    it('should get sector performance using /sector-performance endpoint', async () => {
+    it('should get sector performance snapshot using /sector-performance-snapshot stable endpoint', async () => {
       const mockResponse = {
         success: true,
-        data: [{ sector: 'Technology', changesPercentage: 1.5 }],
+        data: [
+          { date: '2024-06-10', sector: 'Technology', exchange: 'NASDAQ', averageChange: 1.5 },
+        ],
         error: null,
         status: 200,
       };
       mockClient.get.mockResolvedValue(mockResponse);
 
-      const result = await marketEndpoints.getSectorPerformance();
+      const result = await marketEndpoints.getSectorPerformance({ date: '2024-06-10' });
 
-      expect(mockClient.get).toHaveBeenCalledWith('/sector-performance', 'v3');
+      expect(mockClient.get).toHaveBeenCalledWith('/sector-performance-snapshot', 'stable', {
+        date: '2024-06-10',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getIndustryPESnapshot', () => {
+    it('should get industry PE snapshot using /industry-pe-snapshot stable endpoint', async () => {
+      const mockResponse = {
+        success: true,
+        data: [{ date: '2024-06-10', industry: 'Software', exchange: 'NASDAQ', pe: 31.5 }],
+        error: null,
+        status: 200,
+      };
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const result = await marketEndpoints.getIndustryPESnapshot({
+        date: '2024-06-10',
+        exchange: 'NASDAQ',
+      });
+
+      expect(mockClient.get).toHaveBeenCalledWith('/industry-pe-snapshot', 'stable', {
+        date: '2024-06-10',
+        exchange: 'NASDAQ',
+      });
       expect(result).toEqual(mockResponse);
     });
   });

--- a/packages/api/src/__tests__/endpoints/quote.test.ts
+++ b/packages/api/src/__tests__/endpoints/quote.test.ts
@@ -75,6 +75,25 @@ describe('QuoteEndpoints', () => {
     });
   });
 
+  describe('getQuoteShort', () => {
+    it('should get a short quote using /quote-short stable endpoint', async () => {
+      const mockResponse = {
+        success: true,
+        data: { symbol: 'AAPL', price: 150, change: 1.2, volume: 1000000 },
+        error: null,
+        status: 200,
+      };
+      mockClient.getSingle.mockResolvedValue(mockResponse);
+
+      const result = await quoteEndpoints.getQuoteShort('AAPL');
+
+      expect(mockClient.getSingle).toHaveBeenCalledWith('/quote-short', 'stable', {
+        symbol: 'AAPL',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
   describe('getHistoricalPrice', () => {
     it('should get historical prices for any asset type', async () => {
       const mockResponse = {

--- a/packages/api/src/__tests__/endpoints/stock.test.ts
+++ b/packages/api/src/__tests__/endpoints/stock.test.ts
@@ -30,6 +30,25 @@ describe('StockEndpoints', () => {
     });
   });
 
+  describe('getPriceChange', () => {
+    it('should get price change using /stock-price-change stable endpoint', async () => {
+      const mockResponse = {
+        success: true,
+        data: { symbol: 'AAPL', '1D': 1.38, ytd: 8.74, '1Y': 48.4, max: 230231.12 },
+        error: null,
+        status: 200,
+      };
+      mockClient.getSingle.mockResolvedValue(mockResponse);
+
+      const result = await stockEndpoints.getPriceChange('AAPL');
+
+      expect(mockClient.getSingle).toHaveBeenCalledWith('/stock-price-change', 'stable', {
+        symbol: 'AAPL',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
   describe('getStockSplits', () => {
     it('should get stock splits using /historical-price-full/stock_split/{symbol} endpoint', async () => {
       const mockResponse = {

--- a/packages/api/src/__tests__/fmp.test.ts
+++ b/packages/api/src/__tests__/fmp.test.ts
@@ -67,6 +67,7 @@ describe('FMP', () => {
     expect(fmp.mutualFund).toBeDefined();
     expect(fmp.economic).toBeDefined();
     expect(fmp.market).toBeDefined();
+    expect(fmp.aftermarket).toBeDefined();
   });
 
   it('should provide access to underlying client', () => {
@@ -89,6 +90,12 @@ describe('FMP', () => {
     expect(typeof fmp.market.getMarketPerformance).toBe('function');
     expect(typeof fmp.market.getGainers).toBe('function');
     expect(typeof fmp.market.getLosers).toBe('function');
+    expect(typeof fmp.market.getIndustryPESnapshot).toBe('function');
+  });
+
+  it('should have working aftermarket endpoints', () => {
+    expect(typeof fmp.aftermarket.getTrade).toBe('function');
+    expect(typeof fmp.aftermarket.getQuote).toBe('function');
   });
 
   describe('API Key Validation', () => {

--- a/packages/api/src/endpoints/aftermarket.ts
+++ b/packages/api/src/endpoints/aftermarket.ts
@@ -1,0 +1,48 @@
+// Aftermarket (extended-hours) endpoints for FMP API
+
+import { FMPClient } from '@/client';
+import { APIResponse, AftermarketTrade, AftermarketQuote } from 'fmp-node-types';
+
+export class AftermarketEndpoints {
+  constructor(private client: FMPClient) {}
+
+  /**
+   * Get the latest extended-hours (pre/post-market) trade for a symbol
+   *
+   * Returns the most recent aftermarket trade including price, trade size, and
+   * timestamp. Useful for tracking price action outside regular trading hours.
+   *
+   * @param symbol - The stock symbol (e.g., 'AAPL')
+   *
+   * @returns Promise resolving to the latest aftermarket trade
+   *
+   * @example
+   * ```typescript
+   * const trade = await fmp.aftermarket.getTrade('AAPL');
+   * console.log(`Last aftermarket trade: $${trade.data.price} x ${trade.data.tradeSize}`);
+   * ```
+   */
+  async getTrade(symbol: string): Promise<APIResponse<AftermarketTrade>> {
+    return this.client.getSingle('/aftermarket-trade', 'stable', { symbol });
+  }
+
+  /**
+   * Get the latest extended-hours (pre/post-market) bid/ask quote for a symbol
+   *
+   * Returns the most recent aftermarket quote including bid/ask prices and sizes,
+   * volume, and timestamp. Useful for monitoring extended-hours liquidity.
+   *
+   * @param symbol - The stock symbol (e.g., 'AAPL')
+   *
+   * @returns Promise resolving to the latest aftermarket quote
+   *
+   * @example
+   * ```typescript
+   * const quote = await fmp.aftermarket.getQuote('AAPL');
+   * console.log(`Bid ${quote.data.bidPrice} / Ask ${quote.data.askPrice}`);
+   * ```
+   */
+  async getQuote(symbol: string): Promise<APIResponse<AftermarketQuote>> {
+    return this.client.getSingle('/aftermarket-quote', 'stable', { symbol });
+  }
+}

--- a/packages/api/src/endpoints/market.ts
+++ b/packages/api/src/endpoints/market.ts
@@ -3,9 +3,10 @@
 import { FMPClient } from '@/client';
 import {
   APIResponse,
-  MarketHours,
+  ExchangeMarketHours,
   MarketPerformance,
   MarketSectorPerformance,
+  IndustryPESnapshot,
   MarketIndex,
 } from 'fmp-node-types';
 
@@ -13,35 +14,32 @@ export class MarketEndpoints {
   constructor(private client: FMPClient) {}
 
   /**
-   * Get current market hours and trading status
+   * Get trading hours and current open/closed status for all exchanges
    *
-   * Provides real-time information about market trading hours, including
-   * whether markets are currently open or closed, trading session times,
-   * and upcoming market holidays. Essential for determining trading
-   * availability and market status.
+   * Returns one record per supported exchange (NYSE, NASDAQ, LSE, etc.) with its
+   * opening/closing hours, timezone, and whether it is currently open. Essential
+   * for determining trading availability across global markets.
    *
-   * @returns Promise resolving to market hours data with trading status and session information
+   * @returns Promise resolving to an array of per-exchange market-hours records
    *
    * @example
    * ```typescript
-   * // Get current market status
-   * const marketHours = await fmp.market.getMarketHours();
-   * console.log(`Market is ${marketHours.data.isTheStockMarketOpen ? 'OPEN' : 'CLOSED'}`);
-   * console.log(`Current time: ${marketHours.data.currentTime}`);
-   * console.log(`Next trading day: ${marketHours.data.nextTradingDay}`);
+   * // Get market status for every exchange
+   * const hours = await fmp.market.getMarketHours();
    *
-   * // Check if it's a trading day
-   * if (marketHours.data.isTheStockMarketOpen) {
-   *   console.log('Markets are currently open for trading');
-   * } else {
-   *   console.log('Markets are closed');
-   * }
+   * // Check whether the NASDAQ is currently open
+   * const nasdaq = hours.data.find(e => e.exchange === 'NASDAQ');
+   * console.log(`NASDAQ is ${nasdaq?.isMarketOpen ? 'OPEN' : 'CLOSED'}`);
+   *
+   * // List all currently-open exchanges
+   * const open = hours.data.filter(e => e.isMarketOpen).map(e => e.exchange);
+   * console.log(`Open now: ${open.join(', ')}`);
    * ```
    *
-   * @see {@link https://site.financialmodelingprep.com/developer/docs#market-hours|FMP Market Hours Documentation}
+   * @see {@link https://site.financialmodelingprep.com/developer/docs/stable/all-exchange-market-hours|FMP Exchange Market Hours Documentation}
    */
-  async getMarketHours(): Promise<APIResponse<MarketHours>> {
-    return this.client.get('/market-hours', 'v3');
+  async getMarketHours(): Promise<APIResponse<ExchangeMarketHours[]>> {
+    return this.client.get('/all-exchange-market-hours', 'stable');
   }
 
   /**
@@ -205,55 +203,68 @@ export class MarketEndpoints {
   }
 
   /**
-   * Get sector performance data for the current trading day
+   * Get a sector-performance snapshot for a given date
    *
-   * Provides performance data for all major market sectors including
-   * technology, healthcare, financials, energy, and others. Essential for
-   * sector rotation analysis, identifying leading/lagging sectors, and
-   * understanding market breadth and sector-specific trends.
+   * Returns the average price change per sector for the requested date, broken
+   * out by exchange. Essential for sector-rotation analysis and identifying
+   * leading/lagging sectors. A `date` is required (YYYY-MM-DD).
    *
-   * @returns Promise resolving to array of sector performance data with percentage changes
+   * @param params - Snapshot parameters
+   * @param params.date - The date to snapshot, in YYYY-MM-DD format (required)
+   * @param params.exchange - Optional exchange filter (e.g. 'NASDAQ', 'NYSE')
+   * @param params.sector - Optional sector filter (e.g. 'Technology')
+   *
+   * @returns Promise resolving to an array of per-sector average changes
    *
    * @example
    * ```typescript
-   * // Get sector performance for the day
-   * const sectorPerformance = await fmp.market.getSectorPerformance();
-   * console.log(`Sector performance for ${sectorPerformance.data.length} sectors:`);
-   *
-   * sectorPerformance.data.forEach(sector => {
-   *   const changeColor = sector.changesPercentage >= 0 ? 'green' : 'red';
-   *   console.log(`${sector.sector}: ${sector.changesPercentage}%`);
-   *   console.log(`  Change: ${sector.changesPercentage >= 0 ? '+' : ''}${sector.changesPercentage}%`);
+   * const snapshot = await fmp.market.getSectorPerformance({ date: '2024-06-10' });
+   * snapshot.data.forEach(s => {
+   *   console.log(`${s.sector} (${s.exchange}): ${s.averageChange.toFixed(2)}%`);
    * });
    *
-   * // Find best performing sectors
-   * const topSectors = sectorPerformance.data
-   *   .sort((a, b) => b.changesPercentage - a.changesPercentage)
-   *   .slice(0, 3);
-   * console.log('Top 3 performing sectors:');
-   * topSectors.forEach((sector, index) => {
-   *   console.log(`${index + 1}. ${sector.sector}: ${sector.changesPercentage}%`);
-   * });
-   *
-   * // Find worst performing sectors
-   * const bottomSectors = sectorPerformance.data
-   *   .sort((a, b) => a.changesPercentage - b.changesPercentage)
-   *   .slice(0, 3);
-   * console.log('Bottom 3 performing sectors:');
-   * bottomSectors.forEach((sector, index) => {
-   *   console.log(`${index + 1}. ${sector.sector}: ${sector.changesPercentage}%`);
-   * });
-   *
-   * // Check for sector rotation
-   * const gainingSectors = sectorPerformance.data.filter(sector => sector.changesPercentage > 0);
-   * const losingSectors = sectorPerformance.data.filter(sector => sector.changesPercentage < 0);
-   * console.log(`Sectors gaining: ${gainingSectors.length}, Sectors losing: ${losingSectors.length}`);
+   * // Filter to a single exchange
+   * const nyse = await fmp.market.getSectorPerformance({ date: '2024-06-10', exchange: 'NYSE' });
    * ```
    *
-   * @see {@link https://site.financialmodelingprep.com/developer/docs#sector-performance-market-overview|FMP Sector Performance Documentation}
+   * @see {@link https://site.financialmodelingprep.com/developer/docs/stable/sector-performance-snapshot|FMP Sector Performance Snapshot Documentation}
    */
-  async getSectorPerformance(): Promise<APIResponse<MarketSectorPerformance[]>> {
-    return this.client.get('/sector-performance', 'v3');
+  async getSectorPerformance(params: {
+    date: string;
+    exchange?: string;
+    sector?: string;
+  }): Promise<APIResponse<MarketSectorPerformance[]>> {
+    return this.client.get('/sector-performance-snapshot', 'stable', params);
+  }
+
+  /**
+   * Get an industry P/E snapshot for a given date
+   *
+   * Returns the average price-to-earnings ratio per industry for the requested
+   * date, broken out by exchange. Useful for relative-valuation analysis across
+   * industries. A `date` is required (YYYY-MM-DD).
+   *
+   * @param params - Snapshot parameters
+   * @param params.date - The date to snapshot, in YYYY-MM-DD format (required)
+   * @param params.exchange - Optional exchange filter (e.g. 'NASDAQ', 'NYSE')
+   * @param params.industry - Optional industry filter (e.g. 'Software')
+   *
+   * @returns Promise resolving to an array of per-industry P/E ratios
+   *
+   * @example
+   * ```typescript
+   * const pe = await fmp.market.getIndustryPESnapshot({ date: '2024-06-10' });
+   * pe.data.forEach(i => console.log(`${i.industry} (${i.exchange}): ${i.pe.toFixed(1)}`));
+   * ```
+   *
+   * @see {@link https://site.financialmodelingprep.com/developer/docs/stable/industry-pe-snapshot|FMP Industry PE Snapshot Documentation}
+   */
+  async getIndustryPESnapshot(params: {
+    date: string;
+    exchange?: string;
+    industry?: string;
+  }): Promise<APIResponse<IndustryPESnapshot[]>> {
+    return this.client.get('/industry-pe-snapshot', 'stable', params);
   }
 
   /**

--- a/packages/api/src/endpoints/quote.ts
+++ b/packages/api/src/endpoints/quote.ts
@@ -1,7 +1,13 @@
 // Unified quote endpoints for FMP API - handles stocks, crypto, forex, commodities, and ETFs
 
 import { FMPClient } from '@/client';
-import { APIResponse, Quote, HistoricalPriceResponse, IntradayPrice } from 'fmp-node-types';
+import {
+  APIResponse,
+  Quote,
+  QuoteShort,
+  HistoricalPriceResponse,
+  IntradayPrice,
+} from 'fmp-node-types';
 
 export class QuoteEndpoints {
   constructor(private client: FMPClient) {}
@@ -31,6 +37,26 @@ export class QuoteEndpoints {
   async getQuote(symbol: string): Promise<APIResponse<Quote>> {
     // All asset types use the same /quote/{symbol} endpoint
     return this.client.getSingle(`/quote/${symbol}`, 'v3');
+  }
+
+  /**
+   * Get a short real-time quote for any asset type (stocks, crypto, forex, commodities, ETFs)
+   *
+   * A lean alternative to {@link getQuote} returning only price, change, and volume.
+   * Lighter on bandwidth — useful for frequent polling or large symbol sweeps.
+   *
+   * @param symbol - The trading symbol (e.g., 'AAPL', 'BTCUSD', 'EURUSD')
+   *
+   * @returns Promise resolving to a short quote with price, change, and volume
+   *
+   * @example
+   * ```typescript
+   * const shortQuote = await fmp.quote.getQuoteShort('AAPL');
+   * console.log(`${shortQuote.data.price} (${shortQuote.data.change})`);
+   * ```
+   */
+  async getQuoteShort(symbol: string): Promise<APIResponse<QuoteShort>> {
+    return this.client.getSingle('/quote-short', 'stable', { symbol });
   }
 
   /**

--- a/packages/api/src/endpoints/stock.ts
+++ b/packages/api/src/endpoints/stock.ts
@@ -6,6 +6,7 @@ import {
   StockDividendResponse,
   StockRealTimePrice,
   StockRealTimePriceFull,
+  StockPriceChange,
   StockListResponse,
   CompaniesPriceListResponse,
 } from 'fmp-node-types';
@@ -38,6 +39,26 @@ export class StockEndpoints {
    */
   async getMarketCap(symbol: string): Promise<APIResponse<MarketCap>> {
     return this.client.getSingle(`/market-capitalization/${symbol}`, 'v3');
+  }
+
+  /**
+   * Get the percentage price change for a stock across standard horizons
+   *
+   * Returns price change percentages over 1D, 5D, 1M, 3M, 6M, YTD, 1Y, 3Y, 5Y,
+   * 10Y, and max ranges in a single call. Handy for performance summaries.
+   *
+   * @param symbol - The stock symbol (e.g., 'AAPL')
+   *
+   * @returns Promise resolving to price-change percentages across horizons
+   *
+   * @example
+   * ```typescript
+   * const change = await fmp.stock.getPriceChange('AAPL');
+   * console.log(`YTD: ${change.data.ytd}% | 1Y: ${change.data['1Y']}%`);
+   * ```
+   */
+  async getPriceChange(symbol: string): Promise<APIResponse<StockPriceChange>> {
+    return this.client.getSingle('/stock-price-change', 'stable', { symbol });
   }
 
   /**

--- a/packages/api/src/fmp.ts
+++ b/packages/api/src/fmp.ts
@@ -24,6 +24,7 @@ import { TechnicalEndpoints } from './endpoints/technical';
 import { SECEndpoints } from './endpoints/sec';
 import { SenateHouseEndpoints } from './endpoints/senate-house';
 import { StockEndpoints } from './endpoints/stock';
+import { AftermarketEndpoints } from './endpoints/aftermarket';
 
 /**
  * Main FMP API client that provides access to all endpoints
@@ -76,6 +77,7 @@ export class FMP {
   public readonly sec: SECEndpoints;
   public readonly senateHouse: SenateHouseEndpoints;
   public readonly stock: StockEndpoints;
+  public readonly aftermarket: AftermarketEndpoints;
 
   constructor(config: FMPConfig = {}) {
     // Get API key from config or environment variable
@@ -114,6 +116,7 @@ export class FMP {
     this.sec = new SECEndpoints(client);
     this.senateHouse = new SenateHouseEndpoints(client);
     this.stock = new StockEndpoints(client);
+    this.aftermarket = new AftermarketEndpoints(client);
   }
 
   /**

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,6 +28,7 @@ export { AnalystEndpoints } from './endpoints/analyst';
 export { ValuationEndpoints } from './endpoints/valuation';
 export { TechnicalEndpoints } from './endpoints/technical';
 export { StockEndpoints } from './endpoints/stock';
+export { AftermarketEndpoints } from './endpoints/aftermarket';
 export { SenateHouseEndpoints } from './endpoints/senate-house';
 export { SECEndpoints } from './endpoints/sec';
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmp-ai-tools",
-  "version": "0.2.1",
+  "version": "0.2.3-beta.0",
   "description": "AI tools for FMP Node API - compatible with Vercel AI SDK, Langchain, OpenAI, and more",
   "exports": {
     "./vercel-ai": {

--- a/packages/tools/scripts/test-tools-simple.ts
+++ b/packages/tools/scripts/test-tools-simple.ts
@@ -223,7 +223,9 @@ function getTestParameters(toolName: string): any {
     case 'getMarketPerformance':
       return {};
     case 'getSectorPerformance':
-      return {};
+      return { date: '2024-06-10' };
+    case 'getIndustryPESnapshot':
+      return { date: '2024-06-10' };
     case 'getGainers':
       return {};
     case 'getLosers':

--- a/packages/tools/src/__tests__/definitions/consistency.test.ts
+++ b/packages/tools/src/__tests__/definitions/consistency.test.ts
@@ -7,9 +7,9 @@ import { fmpTools as openaiTools } from '@/providers/openai';
 describe('cross-provider consistency', () => {
   const names = allDefinitions.map(d => d.name);
 
-  it('has 56 uniquely-named definitions', () => {
-    expect(names.length).toBe(56);
-    expect(new Set(names).size).toBe(56);
+  it('has 61 uniquely-named definitions', () => {
+    expect(names.length).toBe(61);
+    expect(new Set(names).size).toBe(61);
   });
 
   it('Vercel AI exposes exactly the defined tools', () => {

--- a/packages/tools/src/__tests__/providers/openai/index.test.ts
+++ b/packages/tools/src/__tests__/providers/openai/index.test.ts
@@ -42,6 +42,11 @@ describe('OpenAI providers index exports', () => {
       'getMarketCap',
       'getStockSplits',
       'getDividendHistory',
+      'getStockQuoteShort',
+      'getStockPriceChange',
+      'getIndustryPESnapshot',
+      'getAftermarketTrade',
+      'getAftermarketQuote',
     ];
 
     keys.forEach(k => expect(OpenAIProviders).toHaveProperty(k));
@@ -60,6 +65,7 @@ describe('OpenAI providers index exports', () => {
       'quoteTools',
       'senateHouseTools',
       'stockTools',
+      'aftermarketTools',
       'fmpTools',
     ];
 

--- a/packages/tools/src/__tests__/providers/openai/market.test.ts
+++ b/packages/tools/src/__tests__/providers/openai/market.test.ts
@@ -34,8 +34,11 @@ describe('OpenAI Market Tools (minimal coverage)', () => {
 
   it('getSectorPerformance executes and returns data', async () => {
     mockMarket.getSectorPerformance.mockResolvedValueOnce({ data: [{ sector: 'Technology' }] });
-    const result = await (getSectorPerformance as any).execute({});
-    expect(mockMarket.getSectorPerformance).toHaveBeenCalled();
+    const result = await (getSectorPerformance as any).execute({ date: '2024-06-10' });
+    expect(mockMarket.getSectorPerformance).toHaveBeenCalledWith({
+      date: '2024-06-10',
+      exchange: undefined,
+    });
     expect(JSON.parse(result)).toEqual([{ sector: 'Technology' }]);
   });
 

--- a/packages/tools/src/__tests__/providers/vercel-ai/index.test.ts
+++ b/packages/tools/src/__tests__/providers/vercel-ai/index.test.ts
@@ -1,7 +1,10 @@
 import { fmpTools } from '../../../providers/vercel-ai';
 
 const mockClient = {
-  quote: { getQuote: jest.fn().mockResolvedValue({ data: {} }) },
+  quote: {
+    getQuote: jest.fn().mockResolvedValue({ data: {} }),
+    getQuoteShort: jest.fn().mockResolvedValue({ data: {} }),
+  },
   company: {
     getCompanyProfile: jest.fn().mockResolvedValue({ data: {} }),
     getSharesFloat: jest.fn().mockResolvedValue({ data: {} }),
@@ -38,6 +41,7 @@ const mockClient = {
   market: {
     getMarketPerformance: jest.fn().mockResolvedValue({ data: [] }),
     getSectorPerformance: jest.fn().mockResolvedValue({ data: [] }),
+    getIndustryPESnapshot: jest.fn().mockResolvedValue({ data: [] }),
     getGainers: jest.fn().mockResolvedValue({ data: [] }),
     getLosers: jest.fn().mockResolvedValue({ data: [] }),
     getMostActive: jest.fn().mockResolvedValue({ data: [] }),
@@ -54,6 +58,11 @@ const mockClient = {
     getMarketCap: jest.fn().mockResolvedValue({ data: [] }),
     getStockSplits: jest.fn().mockResolvedValue({ data: [] }),
     getDividendHistory: jest.fn().mockResolvedValue({ data: [] }),
+    getPriceChange: jest.fn().mockResolvedValue({ data: {} }),
+  },
+  aftermarket: {
+    getTrade: jest.fn().mockResolvedValue({ data: {} }),
+    getQuote: jest.fn().mockResolvedValue({ data: {} }),
   },
 };
 
@@ -114,7 +123,8 @@ describe('Vercel AI Provider Index (minimal)', () => {
       getInsiderTrading: { symbol: 'AAPL', page: 0 },
       getInstitutionalHolders: { symbol: 'AAPL' },
       getMarketPerformance: {},
-      getSectorPerformance: {},
+      getSectorPerformance: { date: '2024-06-10' },
+      getIndustryPESnapshot: { date: '2024-06-10' },
       getGainers: {},
       getLosers: {},
       getMostActive: {},
@@ -127,6 +137,10 @@ describe('Vercel AI Provider Index (minimal)', () => {
       getMarketCap: { symbol: 'AAPL' },
       getStockSplits: { symbol: 'AAPL' },
       getDividendHistory: { symbol: 'AAPL' },
+      getStockQuoteShort: { symbol: 'AAPL' },
+      getStockPriceChange: { symbol: 'AAPL' },
+      getAftermarketTrade: { symbol: 'AAPL' },
+      getAftermarketQuote: { symbol: 'AAPL' },
     };
 
     for (const [name, tool] of Object.entries(fmpTools)) {

--- a/packages/tools/src/definitions/aftermarket.ts
+++ b/packages/tools/src/definitions/aftermarket.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { getFMPClient } from '@/client';
+import { toToolResponse } from '@/utils/format-response';
+import { defineTool, type FMPToolDefinition } from './types';
+
+const symbolSchema = z.object({
+  symbol: z
+    .string()
+    .min(1, 'Stock symbol is required')
+    .describe('The stock symbol (e.g., AAPL, MSFT, GOOGL)'),
+});
+
+export const aftermarketDefinitions: FMPToolDefinition[] = [
+  defineTool({
+    name: 'getAftermarketTrade',
+    description:
+      'Get the latest extended-hours (pre/post-market) trade for a symbol, including price, trade size, and timestamp',
+    inputSchema: symbolSchema,
+    execute: async ({ symbol }) =>
+      toToolResponse(await getFMPClient().aftermarket.getTrade(symbol)),
+  }),
+  defineTool({
+    name: 'getAftermarketQuote',
+    description:
+      'Get the latest extended-hours (pre/post-market) bid/ask quote for a symbol, including bid/ask prices and sizes',
+    inputSchema: symbolSchema,
+    execute: async ({ symbol }) =>
+      toToolResponse(await getFMPClient().aftermarket.getQuote(symbol)),
+  }),
+];

--- a/packages/tools/src/definitions/index.ts
+++ b/packages/tools/src/definitions/index.ts
@@ -15,6 +15,7 @@ import { valuationDefinitions } from './valuation';
 import { technicalDefinitions } from './technical';
 import { senateHouseDefinitions } from './senate-house';
 import { stockDefinitions } from './stock';
+import { aftermarketDefinitions } from './aftermarket';
 import type { FMPToolDefinition } from './types';
 
 export * from './types';
@@ -37,6 +38,7 @@ export {
   technicalDefinitions,
   senateHouseDefinitions,
   stockDefinitions,
+  aftermarketDefinitions,
 };
 
 /** Every tool definition, in a stable order shared by all providers. */
@@ -58,4 +60,5 @@ export const allDefinitions: FMPToolDefinition[] = [
   ...technicalDefinitions,
   ...senateHouseDefinitions,
   ...stockDefinitions,
+  ...aftermarketDefinitions,
 ];

--- a/packages/tools/src/definitions/market.ts
+++ b/packages/tools/src/definitions/market.ts
@@ -5,6 +5,15 @@ import { defineTool, type FMPToolDefinition } from './types';
 
 const empty = z.object({});
 
+const snapshotDateSchema = z.object({
+  date: z.string().min(1).describe('Snapshot date in YYYY-MM-DD format'),
+  exchange: z
+    .string()
+    .optional()
+    .nullable()
+    .describe('Optional exchange filter (e.g., NASDAQ, NYSE)'),
+});
+
 export const marketDefinitions: FMPToolDefinition[] = [
   defineTool({
     name: 'getMarketPerformance',
@@ -14,9 +23,29 @@ export const marketDefinitions: FMPToolDefinition[] = [
   }),
   defineTool({
     name: 'getSectorPerformance',
-    description: 'Get sector performance data showing how different market sectors are performing',
-    inputSchema: empty,
-    execute: async () => toToolResponse(await getFMPClient().market.getSectorPerformance()),
+    description:
+      'Get a sector-performance snapshot for a given date, showing the average change per sector by exchange',
+    inputSchema: snapshotDateSchema,
+    execute: async ({ date, exchange }) =>
+      toToolResponse(
+        await getFMPClient().market.getSectorPerformance({
+          date,
+          exchange: exchange ?? undefined,
+        }),
+      ),
+  }),
+  defineTool({
+    name: 'getIndustryPESnapshot',
+    description:
+      'Get an industry P/E snapshot for a given date, showing the average price-to-earnings ratio per industry by exchange',
+    inputSchema: snapshotDateSchema,
+    execute: async ({ date, exchange }) =>
+      toToolResponse(
+        await getFMPClient().market.getIndustryPESnapshot({
+          date,
+          exchange: exchange ?? undefined,
+        }),
+      ),
   }),
   defineTool({
     name: 'getGainers',

--- a/packages/tools/src/definitions/quote.ts
+++ b/packages/tools/src/definitions/quote.ts
@@ -18,6 +18,18 @@ export const quoteDefinitions: FMPToolDefinition[] = [
     execute: async ({ symbol }) => toToolResponse(await getFMPClient().quote.getQuote(symbol)),
   }),
   defineTool({
+    name: 'getStockQuoteShort',
+    description:
+      'Get a short real-time quote (price, change, and volume only) for a symbol. Lighter than the full quote.',
+    inputSchema: z.object({
+      symbol: z
+        .string()
+        .min(1, 'Stock symbol is required')
+        .describe('The symbol to get the short quote for (e.g., AAPL, BTCUSD, EURUSD)'),
+    }),
+    execute: async ({ symbol }) => toToolResponse(await getFMPClient().quote.getQuoteShort(symbol)),
+  }),
+  defineTool({
     name: 'getHistoricalPrice',
     description:
       'Get historical daily prices (open/high/low/close/volume) for a symbol. Returns the most recent `limit` days.',

--- a/packages/tools/src/definitions/stock.ts
+++ b/packages/tools/src/definitions/stock.ts
@@ -31,4 +31,12 @@ export const stockDefinitions: FMPToolDefinition[] = [
     execute: async ({ symbol }) =>
       toToolResponse(await getFMPClient().stock.getDividendHistory(symbol)),
   }),
+  defineTool({
+    name: 'getStockPriceChange',
+    description:
+      'Get the percentage price change for a stock across standard horizons (1D, 5D, 1M, 3M, 6M, YTD, 1Y, 3Y, 5Y, 10Y, max)',
+    inputSchema: symbolSchema,
+    execute: async ({ symbol }) =>
+      toToolResponse(await getFMPClient().stock.getPriceChange(symbol)),
+  }),
 ];

--- a/packages/tools/src/providers/openai/index.ts
+++ b/packages/tools/src/providers/openai/index.ts
@@ -23,6 +23,7 @@ import {
   technicalDefinitions,
   senateHouseDefinitions,
   stockDefinitions,
+  aftermarketDefinitions,
   type FMPToolDefinition,
 } from '@/definitions';
 
@@ -36,6 +37,7 @@ const pick = (defs: FMPToolDefinition[]): Tool<unknown>[] => defs.map(def => byN
 
 // Individual tools for direct import
 export const getStockQuote = byName.getStockQuote;
+export const getStockQuoteShort = byName.getStockQuoteShort;
 export const getHistoricalPrice = byName.getHistoricalPrice;
 export const getIntraday = byName.getIntraday;
 export const getCompanyProfile = byName.getCompanyProfile;
@@ -68,6 +70,7 @@ export const getInsiderTrading = byName.getInsiderTrading;
 export const getInstitutionalHolders = byName.getInstitutionalHolders;
 export const getMarketPerformance = byName.getMarketPerformance;
 export const getSectorPerformance = byName.getSectorPerformance;
+export const getIndustryPESnapshot = byName.getIndustryPESnapshot;
 export const getGainers = byName.getGainers;
 export const getLosers = byName.getLosers;
 export const getMostActive = byName.getMostActive;
@@ -91,6 +94,9 @@ export const getTechnicalIndicator = byName.getTechnicalIndicator;
 export const getMarketCap = byName.getMarketCap;
 export const getStockSplits = byName.getStockSplits;
 export const getDividendHistory = byName.getDividendHistory;
+export const getStockPriceChange = byName.getStockPriceChange;
+export const getAftermarketTrade = byName.getAftermarketTrade;
+export const getAftermarketQuote = byName.getAftermarketQuote;
 
 // Tool groups as arrays for OpenAI Agents
 export const quoteTools = pick(quoteDefinitions);
@@ -110,6 +116,7 @@ export const valuationTools = pick(valuationDefinitions);
 export const technicalTools = pick(technicalDefinitions);
 export const senateHouseTools = pick(senateHouseDefinitions);
 export const stockTools = pick(stockDefinitions);
+export const aftermarketTools = pick(aftermarketDefinitions);
 
 // Combine all tools into a single array
 export const fmpTools: Tool<unknown>[] = allDefinitions.map(def => byName[def.name]);

--- a/packages/tools/src/providers/vercel-ai/index.ts
+++ b/packages/tools/src/providers/vercel-ai/index.ts
@@ -22,6 +22,7 @@ import {
   technicalDefinitions,
   senateHouseDefinitions,
   stockDefinitions,
+  aftermarketDefinitions,
   type FMPToolDefinition,
 } from '@/definitions';
 
@@ -47,6 +48,7 @@ export const valuationTools = toToolSet(valuationDefinitions);
 export const technicalTools = toToolSet(technicalDefinitions);
 export const senateHouseTools = toToolSet(senateHouseDefinitions);
 export const stockTools = toToolSet(stockDefinitions);
+export const aftermarketTools = toToolSet(aftermarketDefinitions);
 
 // Combine all tools into a single ToolSet
 export const fmpTools: ToolSet = {
@@ -67,10 +69,11 @@ export const fmpTools: ToolSet = {
   ...technicalTools,
   ...senateHouseTools,
   ...stockTools,
+  ...aftermarketTools,
 };
 
 // Individual tools for direct import
-export const { getStockQuote, getHistoricalPrice, getIntraday } = quoteTools;
+export const { getStockQuote, getStockQuoteShort, getHistoricalPrice, getIntraday } = quoteTools;
 export const {
   getCompanyProfile,
   getCompanySharesFloat,
@@ -100,8 +103,14 @@ export const {
 } = financialTools;
 export const { getInsiderTrading } = insiderTools;
 export const { getInstitutionalHolders } = institutionalTools;
-export const { getMarketPerformance, getSectorPerformance, getGainers, getLosers, getMostActive } =
-  marketTools;
+export const {
+  getMarketPerformance,
+  getSectorPerformance,
+  getIndustryPESnapshot,
+  getGainers,
+  getLosers,
+  getMostActive,
+} = marketTools;
 export const {
   getSenateTrading,
   getHouseTrading,
@@ -117,4 +126,5 @@ export const { getAnalystEstimates, getPriceTargetConsensus, getStockGrades, get
   analystTools;
 export const { getDiscountedCashFlow, getCompanyRating } = valuationTools;
 export const { getTechnicalIndicator } = technicalTools;
-export const { getMarketCap, getStockSplits, getDividendHistory } = stockTools;
+export const { getMarketCap, getStockSplits, getDividendHistory, getStockPriceChange } = stockTools;
+export const { getAftermarketTrade, getAftermarketQuote } = aftermarketTools;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmp-node-types",
-  "version": "0.2.0",
+  "version": "0.2.3-beta.0",
   "description": "Shared TypeScript types for FMP Node Wrapper ecosystem (internal package)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/types/src/aftermarket.ts
+++ b/packages/types/src/aftermarket.ts
@@ -1,0 +1,30 @@
+// Aftermarket (extended-hours) types for FMP API
+//
+// Schema-first: Zod schemas are the source of truth; TypeScript types are
+// derived via `z.infer`. Field shapes confirmed against the live `stable`
+// surface (aftermarket-trade / aftermarket-quote).
+
+import { z } from 'zod';
+
+// Latest extended-hours trade (stable /aftermarket-trade).
+export const AftermarketTradeSchema = z.object({
+  symbol: z.string(),
+  price: z.number(),
+  tradeSize: z.number(),
+  timestamp: z.number(),
+});
+
+export type AftermarketTrade = z.infer<typeof AftermarketTradeSchema>;
+
+// Latest extended-hours bid/ask (stable /aftermarket-quote).
+export const AftermarketQuoteSchema = z.object({
+  symbol: z.string(),
+  bidSize: z.number(),
+  bidPrice: z.number(),
+  askSize: z.number(),
+  askPrice: z.number(),
+  volume: z.number(),
+  timestamp: z.number(),
+});
+
+export type AftermarketQuote = z.infer<typeof AftermarketQuoteSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -63,3 +63,6 @@ export * from './senate-house';
 
 // Stock types
 export * from './stock';
+
+// Aftermarket (extended-hours) types
+export * from './aftermarket';

--- a/packages/types/src/market.ts
+++ b/packages/types/src/market.ts
@@ -6,37 +6,18 @@
 import { z } from 'zod';
 import { QuoteSchema } from './quote';
 
-// The named-holiday keys vary year to year (e.g. Juneteenth only appears from
-// 2021), so every holiday field except `year` is optional.
-export const MarketHolidaySchema = z.object({
-  year: z.number(),
-  'Martin Luther King, Jr. Day': z.string().optional(),
-  "Presidents' Day": z.string().optional(),
-  'Good Friday': z.string().optional(),
-  'Memorial Day': z.string().optional(),
-  Juneteenth: z.string().optional(),
-  'Independence Day': z.string().optional(),
-  'Labor Day': z.string().optional(),
-  'Thanksgiving Day': z.string().optional(),
-  Christmas: z.string().optional(),
+// Trading hours + current open/closed status for a single exchange.
+// One element per exchange from the stable /all-exchange-market-hours endpoint.
+export const ExchangeMarketHoursSchema = z.object({
+  exchange: z.string(),
+  name: z.string(),
+  openingHour: z.string(),
+  closingHour: z.string(),
+  timezone: z.string(),
+  isMarketOpen: z.boolean(),
 });
 
-export type MarketHoliday = z.infer<typeof MarketHolidaySchema>;
-
-export const MarketHoursSchema = z.object({
-  stockExchangeName: z.string(),
-  stockMarketHours: z.object({
-    openingHour: z.string(),
-    closingHour: z.string(),
-  }),
-  stockMarketHolidays: z.array(MarketHolidaySchema),
-  isTheStockMarketOpen: z.boolean(),
-  isTheEuronextMarketOpen: z.boolean(),
-  isTheForexMarketOpen: z.boolean(),
-  isTheCryptoMarketOpen: z.boolean(),
-});
-
-export type MarketHours = z.infer<typeof MarketHoursSchema>;
+export type ExchangeMarketHours = z.infer<typeof ExchangeMarketHoursSchema>;
 
 export const MarketPerformanceSchema = z.object({
   symbol: z.string(),
@@ -50,13 +31,26 @@ export const MarketPerformanceSchema = z.object({
 
 export type MarketPerformance = z.infer<typeof MarketPerformanceSchema>;
 
+// Per-sector average change for a given date/exchange (stable
+// /sector-performance-snapshot). `averageChange` is a numeric percentage.
 export const MarketSectorPerformanceSchema = z.object({
+  date: z.string(),
   sector: z.string(),
-  // The sector-performance endpoint returns this as a formatted string (e.g. "1.23%").
-  changesPercentage: z.string(),
+  exchange: z.string(),
+  averageChange: z.number(),
 });
 
 export type MarketSectorPerformance = z.infer<typeof MarketSectorPerformanceSchema>;
+
+// Per-industry P/E for a given date/exchange (stable /industry-pe-snapshot).
+export const IndustryPESnapshotSchema = z.object({
+  date: z.string(),
+  industry: z.string(),
+  exchange: z.string(),
+  pe: z.number(),
+});
+
+export type IndustryPESnapshot = z.infer<typeof IndustryPESnapshotSchema>;
 
 // The `/quotes/index` endpoint (used by both getMarketIndex and
 // getMarketPerformance) returns full quote objects for market indices — the

--- a/packages/types/src/quote.ts
+++ b/packages/types/src/quote.ts
@@ -34,6 +34,16 @@ export const QuoteSchema = z.object({
 
 export type Quote = z.infer<typeof QuoteSchema>;
 
+// Short quote (stable /quote-short) — a lean price/change/volume snapshot.
+export const QuoteShortSchema = z.object({
+  symbol: z.string(),
+  price: z.number(),
+  change: z.number(),
+  volume: z.number(),
+});
+
+export type QuoteShort = z.infer<typeof QuoteShortSchema>;
+
 // Historical price data structure
 export const HistoricalPriceDataSchema = z.object({
   date: z.string(),

--- a/packages/types/src/stock.ts
+++ b/packages/types/src/stock.ts
@@ -72,6 +72,25 @@ export const StockRealTimePriceFullSchema = z.object({
 
 export type StockRealTimePriceFull = z.infer<typeof StockRealTimePriceFullSchema>;
 
+// Price change across standard horizons (stable /stock-price-change).
+// Values are percentage changes; keys mirror FMP's numeric-prefixed fields.
+export const StockPriceChangeSchema = z.object({
+  symbol: z.string(),
+  '1D': z.number(),
+  '5D': z.number(),
+  '1M': z.number(),
+  '3M': z.number(),
+  '6M': z.number(),
+  ytd: z.number(),
+  '1Y': z.number(),
+  '3Y': z.number(),
+  '5Y': z.number(),
+  '10Y': z.number(),
+  max: z.number(),
+});
+
+export type StockPriceChange = z.infer<typeof StockPriceChangeSchema>;
+
 // Generic response wrappers — kept as plain interfaces because Zod schemas
 // cannot represent open generics. Not part of the schema-first surface.
 


### PR DESCRIPTION
Add seven FMP `stable`-surface endpoints across types, api, tools, and docs:

- quote.getQuoteShort(symbol) - lean price/change/volume quote
- new aftermarket endpoint class: aftermarket.getTrade / getQuote (pre/post-market)
- stock.getPriceChange(symbol) - change across 1D..10Y/max horizons
- market.getIndustryPESnapshot({ date }) - per-industry P/E snapshot

Breaking (v3 -> stable):
- market.getMarketHours() now returns ExchangeMarketHours[] (per-exchange, with isMarketOpen); MarketHours/MarketHoliday types removed
- market.getSectorPerformance() now requires { date } and returns the snapshot shape { date, sector, exchange, averageChange }

Each endpoint flows through a Zod schema (fmp-node-types), endpoint method (fmp-node-api), mocked Jest test, live manifest case, and an AI tool for both the Vercel AI SDK and OpenAI Agents, plus docs + README. Sector/industry snapshots are plan-locked for historical dates on Starter.